### PR TITLE
Allow web access to json directory

### DIFF
--- a/debian/lighttpd/89-dump1090.conf
+++ b/debian/lighttpd/89-dump1090.conf
@@ -2,18 +2,17 @@
 # and also to the dynamically-generated json parts that contain aircraft
 # data and are periodically written by the dump1090 daemon.
 
-url.redirect += (
-  "^/dump1090/$" => "/dump1090/gmap.html",
+url.redirect = (
   "^/dump1090$" => "/dump1090/gmap.html"
 )
 
-alias.url += (
-  "/dump1090/data/" => "/run/dump1090-mutability/",
-  "/dump1090/db/" => "/var/cache/dump1090-mutability/db/",
-  "/dump1090/" => "/usr/share/dump1090-mutability/html/"
+alias.url = (
+  "/dump1090/data" => "/run/dump1090-mutability/",
+  "/dump1090" => "/usr/share/dump1090-mutability/html/"
 )
 
 # The stat cache must be disabled, as aircraft.json changes
 # frequently and lighttpd's stat cache often ends up with the
 # wrong content length.
 server.stat-cache-engine    = "disable"
+dir-listing.activate        = "enable"


### PR DESCRIPTION
Update url alias to point to data directory and allow for directory listing of json files. Remove superfluous redirect rule for gmap.html. Update url alias right hand side for trailing backslash (per lighttpd alias suggestions.)
