### PR TITLE
User KML Overlay Support

### DIFF
--- a/public_html/config.js
+++ b/public_html/config.js
@@ -39,6 +39,11 @@ SiteLat     = 45.0;            // position of the marker
 SiteLon     = 9.0;
 SiteName    = "My Radar Site"; // tooltip of the marker
 
+//User Map (KML File)
+//Enables KML overlay on map, UserMap must have a value below when "true"
+UserMapShow = false;            //true to show KML
+//KML to show: 
+UserMap     = "";               //Fully qualified local path or URL
 
 // -- Marker settings -------------------------------------
 

--- a/public_html/config.js
+++ b/public_html/config.js
@@ -43,7 +43,7 @@ SiteName    = "My Radar Site"; // tooltip of the marker
 //Enables KML overlay on map, UserMap must have a value below when "true"
 UserMapShow = false;            //true to show KML
 //KML to show: 
-UserMap     = "";               //Fully qualified local path or URL
+UserMap     = "";               //URL (publicly available domain)
 
 // -- Marker settings -------------------------------------
 

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -7,6 +7,7 @@ var Planes        = {};
 var PlanesOrdered = [];
 var SelectedPlane = null;
 var FollowSelected = false;
+var UserKML	  = null;
 
 var SpecialSquawks = {
         '7500' : { cssClass: 'squawk7500', markerColor: 'rgb(255, 85, 85)', text: 'Aircraft Hijacking' },
@@ -457,6 +458,15 @@ function initialize_map() {
               drawCircle(marker, SiteCirclesDistances[i]); // in meters
             }
         }
+	}
+	
+	//Add User Map layer if requested
+	if (UserMapShow) {
+	    UserKML = new google.maps.KmlLayer({
+		url: UserMap,
+		map: GoogleMap,
+		preserveViewport: true
+	    	});
 	}
 }
 


### PR DESCRIPTION
I use a KML file to overlay Air Traffic Control Center boundaries and thought maybe others might want to see their own custom overlays.

The Google Maps extension used to generate the base map supports KML layers. Added a user switch and map definition in config.js and layer code in script.js.
