### PR TITLE
Use consistent directory naming for html folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 
 ifdef PREFIX
 BINDIR=$(PREFIX)/bin
-SHAREDIR=$(PREFIX)/share/$(PROGNAME)
+SHAREDIR=$(PREFIX)/share/$(PROGNAME)/public_html
 EXTRACFLAGS=-DHTMLPATH=\"$(SHAREDIR)\"
 endif
 


### PR DESCRIPTION
The public_html suffix to the html dir gets skipped when PREFIX is defined, use the public_html suffix in all cases
