### PR TITLE
MinGW support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+*.css text eol=lf
+*.js text eol=lf
+*.html text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ frames.js
 untrackedDeveloperSettings.js
 view1090
 faup1090
+*.exe

--- a/anet.c
+++ b/anet.c
@@ -62,8 +62,8 @@ static void anetSetError(char *err, const char *fmt, ...)
 
 int anetNonBlock(char *err, int fd)
 {
-    int flags;
 #ifndef _WIN32
+    int flags;
     /* Set the socket nonblocking.
      * Note that fcntl(2) for F_GETFL and F_SETFL can't be
      * interrupted by a signal. */
@@ -76,7 +76,7 @@ int anetNonBlock(char *err, int fd)
         return ANET_ERR;
     }
 #else
-    flags = 1;
+    u_long flags = 1;
     if (ioctlsocket(fd, FIONBIO, &flags)) {
         errno = WSAGetLastError();
         anetSetError(err, "ioctlsocket(FIONBIO): %s", strerror(errno));

--- a/anet.c
+++ b/anet.c
@@ -45,7 +45,7 @@
   #include <stdio.h>
 #else
   #include "winstubs.h" //Put everything Windows specific in here
-  #include "dump1090.h"
+  #include <stdint.h>
 #endif
 
 #include "anet.h"

--- a/dump1090.c
+++ b/dump1090.c
@@ -1227,9 +1227,8 @@ int main(int argc, char **argv) {
     cleanup_converter(Modes.converter_state);
     log_with_timestamp("Normal exit.");
 
-#ifndef _WIN32
     pthread_exit(0);
-#else
+#ifdef _WIN32
     return (0);
 #endif
 }

--- a/dump1090.c
+++ b/dump1090.c
@@ -631,9 +631,8 @@ void *readerThreadEntryPoint(void *arg) {
     pthread_cond_signal(&Modes.data_cond);
     pthread_mutex_unlock(&Modes.data_mutex);
 
-#ifndef _WIN32
     pthread_exit(NULL);
-#else
+#ifdef _WIN32
     return NULL;
 #endif
 }

--- a/dump1090.c
+++ b/dump1090.c
@@ -1080,11 +1080,6 @@ int main(int argc, char **argv) {
         }
     }
 
-#ifdef _WIN32
-    // Try to comply with the Copyright license conditions for binary distribution
-    if (!Modes.quiet) {showCopyright();}
-#endif
-
 #ifndef _WIN32
     // Setup for SIGWINCH for handling lines
     if (Modes.interactive) {signal(SIGWINCH, sigWinchCallback);}

--- a/mingw/Makefile
+++ b/mingw/Makefile
@@ -1,0 +1,52 @@
+DUMP1090_VERSION ?= v1.14-67-g650e58a
+#-$(shell git describe --tags)
+
+INC_RTL ?= -I../../../rtl-sdr/include
+LIB_RTL ?= -L../../../rtl-sdr/libs -lrtlsdr
+
+OPT = -O3 -flto
+REL = -s
+
+CC     := gcc
+CFLAGS += -Wall -Werror -std=c99 -I.
+LIBS    = -lws2_32
+DUMPVER = -DMODES_DUMP1090_VERSION=\"$(DUMP1090_VERSION)\"
+
+SHARED_O = anet.o mode_ac.o mode_s.o net_io.o crc.o stats.o cpr.o icao_filter.o track.o util.o
+DUMP1090_O = dump1090.o interactive.o demod_2000.o demod_2400.o convert.o $(SHARED_O)
+VIEW1090_O = view1090.o interactive.o $(SHARED_O)
+FAUP1090_O = faup1090.o $(SHARED_O)
+
+.PHONY: clean
+
+all: dump1090 view1090
+
+%.o: ../%.c ../*.h
+	$(CC) $(OPT) $(CFLAGS) -c $< -o $@
+
+dump1090.o: CFLAGS += $(DUMPVER) $(INC_RTL)
+view1090.o: CFLAGS += $(DUMPVER)
+faup1090.o: CFLAGS += $(DUMPVER)
+net_io.o:   CFLAGS += $(DUMPVER)
+
+dump1090: $(DUMP1090_O)
+	$(CC) $(OPT) $(REL) -o $@ $^ $(LIBS) $(LIB_RTL)
+
+view1090: $(VIEW1090_O)
+	$(CC) $(OPT) $(REL) -o $@ $^ $(LIBS)
+
+faup1090: $(FAUP1090_O)
+	$(CC) $(OPT) $(REL) -o $@ $^ $(LIBS)
+
+clean:
+	@if exist *.exe del /q /f *.exe > nul 2>&1
+	@if exist *.o del /q /f *.o > nul 2>&1
+
+test: cprtests
+	./cprtests
+
+cprtests: cpr.o cprtests.o
+	$(CC) $(OPT) $(REL) $(CFLAGS) -o $@ $^
+
+crctests: crc.c crc.h
+	$(CC) $(OPT) $(REL) $(CFLAGS) -DCRCDEBUG -o $@ $<

--- a/mingw/endian.h
+++ b/mingw/endian.h
@@ -1,0 +1,5 @@
+#ifndef __ENDIAN_H
+#define __ENDIAN_H
+/* dummy */
+#endif//__ENDIAN_H
+

--- a/mingw/winstubs.h
+++ b/mingw/winstubs.h
@@ -1,0 +1,45 @@
+#ifndef __WINSTUBS_H
+#define __WINSTUBS_H
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+
+#include <sys/stat.h>
+#include <pthread.h>
+#include <time.h>
+#include <stdio.h>
+#include <math.h>
+#include <fcntl.h>
+
+#define sleep Sleep
+#define realpath(N,R) _fullpath((R),(N),_MAX_PATH)
+#define M_PI 3.14159265358979323846
+
+/* from <endian.h> */
+#if BYTE_ORDER == LITTLE_ENDIAN
+#   define le16toh(x) (x)
+#elif BYTE_ORDER == BIG_ENDIAN
+#   define le16toh(x) __builtin_bswap16(x)
+#endif
+
+
+_inline void fchmod(int A, int B) {(void)A; (void)B;}
+_inline void usleep(UINT32 ulSleep) {Sleep(ulSleep/1000);}
+_inline int inet_aton(const char * cp, DWORD * ulAddr)
+{
+    *ulAddr = inet_addr(cp);
+    return (INADDR_NONE != *ulAddr);
+}
+_inline void cls()
+{
+    HANDLE hStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    COORD coord = {0, 0};
+    DWORD count;
+    CONSOLE_SCREEN_BUFFER_INFO csbi;
+    GetConsoleScreenBufferInfo(hStdOut, &csbi);
+    FillConsoleOutputCharacter(hStdOut, ' ', csbi.dwSize.X * csbi.dwSize.Y, coord, &count);
+    SetConsoleCursorPosition(hStdOut, coord);
+}
+
+#endif // __WINSTUBS_H

--- a/mingw/winstubs.h
+++ b/mingw/winstubs.h
@@ -12,7 +12,6 @@
 #include <math.h>
 #include <fcntl.h>
 
-#define sleep Sleep
 #define realpath(N,R) _fullpath((R),(N),_MAX_PATH)
 #define M_PI 3.14159265358979323846
 
@@ -25,7 +24,8 @@
 
 
 _inline void fchmod(int A, int B) {(void)A; (void)B;}
-_inline void usleep(UINT32 ulSleep) {Sleep(ulSleep/1000);}
+_inline void usleep(DWORD uSecSleep) {Sleep(uSecSleep/1000);}
+_inline void sleep(DWORD secSleep) {Sleep(secSleep*1000);}
 _inline int inet_aton(const char * cp, DWORD * ulAddr)
 {
     *ulAddr = inet_addr(cp);

--- a/net_io.c
+++ b/net_io.c
@@ -196,7 +196,13 @@ struct net_service *makeFatsvOutputService(void)
 void modesInitNet(void) {
     struct net_service *s;
 
+#ifndef _WIN32
     signal(SIGPIPE, SIG_IGN);
+#else
+    if ((!Modes.wsaData.wVersion) && (!Modes.wsaData.wHighVersion))
+        if (WSAStartup(MAKEWORD(2, 1), &Modes.wsaData) != 0)
+            fprintf(stderr, "WSAStartup returned Error\n");
+#endif
     Modes.clients = NULL;
     Modes.services = NULL;
 

--- a/stats.c
+++ b/stats.c
@@ -78,8 +78,13 @@ void display_stats(struct stats *st) {
 
     if (!Modes.net_only) {
         printf("Local receiver:\n");
+#ifndef _WIN32
         printf("  %llu samples processed\n",                        (unsigned long long)st->samples_processed);
         printf("  %llu samples dropped\n",                          (unsigned long long)st->samples_dropped);
+#else
+        printf("  %I64u samples processed\n",                        (unsigned long long)st->samples_processed);
+        printf("  %I64u samples dropped\n",                          (unsigned long long)st->samples_dropped);
+#endif
 
         printf("  %u Mode A/C messages received\n",                 st->demod_modeac);
         printf("  %u Mode-S message preambles received\n",          st->demod_preambles);
@@ -164,9 +169,15 @@ void display_stats(struct stats *st) {
         uint64_t background_cpu_millis = (uint64_t)st->background_cpu.tv_sec*1000UL + st->background_cpu.tv_nsec/1000000UL;
 
         printf("CPU load: %.1f%%\n"
+#ifndef _WIN32
                "  %llu ms for demodulation\n"
                "  %llu ms for reading from USB\n"
                "  %llu ms for network input and background tasks\n",
+#else
+               "  %I64u ms for demodulation\n"
+               "  %I64u ms for reading from USB\n"
+               "  %I64u ms for network input and background tasks\n",
+#endif
                100.0 * (demod_cpu_millis + reader_cpu_millis + background_cpu_millis) / (st->end - st->start + 1),
                (unsigned long long) demod_cpu_millis,
                (unsigned long long) reader_cpu_millis,

--- a/view1090.c
+++ b/view1090.c
@@ -202,12 +202,6 @@ int main(int argc, char **argv) {
         }
     }
 
-#ifdef _WIN32
-    // Try to comply with the Copyright license conditions for binary distribution
-    if (!Modes.quiet) {showCopyright();}
-#define MSG_DONTWAIT 0
-#endif
-
 #ifndef _WIN32
     // Setup for SIGWINCH for handling lines
     if (Modes.interactive) {signal(SIGWINCH, sigWinchCallback);}


### PR DESCRIPTION
Tested with MinGW-builds (http://sourceforge.net/projects/mingwbuilds/), GCC 4.9.2 (i686-posix-dwarf-rev2.

Before compilation is necessary to specify the correct rtl-sdr library path in mingw/Makefile:

```
INC_RTL ?= -I../../../rtl-sdr/include
LIB_RTL ?= -L../../../rtl-sdr/libs -lrtlsdr
```

then just `cd mingw && make`.

Mingw required only for _rtl-sdr.h_, _rtl-sdr_export.h_ and _rtlsdr.dll_, *.a or *.lib is not needed.

small comment, DUMP1090_VERSION is hardcoded in mingw/Makefile at now.
