### PR TITLE
Use invoke-rc.d to restart lighttpd as per Debian policy

### DIFF
--- a/debian/dump1090-mutability.postinst
+++ b/debian/dump1090-mutability.postinst
@@ -126,7 +126,7 @@ case "$1" in
         if [ -e /etc/lighttpd/conf-enabled/89-dump1090.conf ]; then
             if dpkg --compare-versions "$2" le "1.14"; then
                 echo "Restarting lighttpd.." >&2
-                service lighttpd restart || echo "Warning: lighttpd failed to restart." >&2
+                invoke-rc.d lighttpd restart || echo "Warning: lighttpd failed to restart." >&2
             fi
         fi
     ;;


### PR DESCRIPTION
Hi,

init scripts should not be called directly by packages except for very specific reasons. Details at:
https://www.debian.org/doc/debian-policy/ch-opersys.html "9.3.3.2 Running initscripts"
