### PR TITLE
Add additional plane data to gmap

### DIFF
--- a/public_html/gmap.html
+++ b/public_html/gmap.html
@@ -115,6 +115,9 @@
                                         <span id="selected_flag">
                                           <img width="20" height="12">
                                         </span>
+                                        <span id="selected_owner"></span>
+                                        <span id="selected_type"></span>
+                                        <span id="selected_manufacturer"></span>
 
                                         <a href="http://www.airframes.org/" onclick="document.getElementById('horrible_hack').submit.call(document.getElementById('airframes_post')); return false;">
                                           <span id="selected_icao"></span>

--- a/public_html/planeObject.js
+++ b/public_html/planeObject.js
@@ -42,6 +42,9 @@ function PlaneObject(icao) {
         // request metadata
         this.registration = null;
         this.icaotype = null;
+        this.manufacturer = null;
+        this.owner = null;
+        this.type = null;
         getAircraftData(this.icao).done(function(data) {
                 if ("r" in data) {
                         this.registration = data.r;
@@ -50,7 +53,19 @@ function PlaneObject(icao) {
                 if ("t" in data) {
                         this.icaotype = data.t;
                 }
-
+				
+                if ("m" in data) {
+                        this.manufacturer = data.m;
+                }
+				
+                if ("o" in data) {
+                        this.owner = data.o;
+                }
+				
+                if ("s" in data) {
+                        this.type = data.s;
+                }
+                
                 if (this.selected) {
 		        refreshSelected();
                 }

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -582,6 +582,24 @@ function refreshSelected() {
         } else {
                 $('#selected_icaotype').text("");
         }
+		
+        if (selected.owner !== null) {
+                $('#selected_owner').text(selected.owner);
+        } else {
+                $('#selected_owner').text("");
+        }
+		
+        if (selected.type !== null) {
+                $('#selected_type').text(selected.type);
+        } else {
+                $('#selected_type').text("");
+        }
+		
+        if (selected.manufacturer !== null) {
+                $('#selected_manufacturer').text(selected.manufacturer);
+        } else {
+                $('#selected_manufacturer').text("");
+        }
 
         var emerg = document.getElementById('selected_emergency');
         if (selected.squawk in SpecialSquawks) {

--- a/tools/vrs-basicaircraft-to-json.py
+++ b/tools/vrs-basicaircraft-to-json.py
@@ -17,15 +17,30 @@ def extract(dbfile, todir, blocklimit, debug):
         blocks['%01X' % i] = {}
 
     print >>sys.stderr, 'Reading', dbfile
-    with closing(sqlite3.connect(dbfile)) as db:
-        with closing(db.execute('SELECT a.Icao, a.Registration, m.Icao FROM Aircraft a, Model m WHERE a.ModelID = m.ModelID')) as c:
-            for icao24, reg, icaotype in c:
-                bkey = icao24[0:1].upper()
-                dkey = icao24[1:].upper()
-                blocks[bkey][dkey] = {}
-                if reg: blocks[bkey][dkey]['r'] = reg
-                if icaotype: blocks[bkey][dkey]['t'] = icaotype
-                ac_count += 1
+        if "BaseStation.sqb" in dbfile:
+        with closing(sqlite3.connect(dbfile)) as db:
+            with closing(db.execute('SELECT ModeS, Registration, ICAOTypeCode, Manufacturer, RegisteredOwners, Type FROM Aircraft')) as c:
+                for icao24, reg, icaotype, manu, owner, type  in c:
+    				bkey = icao24[0:1].upper()
+    				dkey = icao24[1:].upper()
+    				blocks[bkey][dkey] = {}
+    				if reg: blocks[bkey][dkey]['r'] = reg
+    				if icaotype: blocks[bkey][dkey]['t'] = icaotype
+    				if manu: blocks[bkey][dkey]['m'] = manu
+    				if owner: blocks[bkey][dkey]['o'] = owner
+    				if type: blocks[bkey][dkey]['s'] = type
+    				ac_count += 1
+    else:
+		with closing(sqlite3.connect(dbfile)) as db:
+			with closing(db.execute('SELECT a.Icao, a.Registration, m.Icao, o.Name  FROM Aircraft a, Model m, Operator o WHERE a.ModelID = m.ModelID and a.operatorID = o.operatorID')) as c:
+				for icao24, reg, icaotype, type  in c:
+					bkey = icao24[0:1].upper()
+					dkey = icao24[1:].upper()
+					blocks[bkey][dkey] = {}
+					if reg: blocks[bkey][dkey]['r'] = reg
+					if icaotype: blocks[bkey][dkey]['t'] = icaotype
+					if type: blocks[bkey][dkey]['s'] = type
+					ac_count += 1
     print >>sys.stderr, 'Read', ac_count, 'aircraft'
 
     print >>sys.stderr, 'Writing blocks:',

--- a/tools/vrs-basicaircraft-to-json.py
+++ b/tools/vrs-basicaircraft-to-json.py
@@ -32,13 +32,14 @@ def extract(dbfile, todir, blocklimit, debug):
     				ac_count += 1
         else:
 		with closing(sqlite3.connect(dbfile)) as db:
-			with closing(db.execute('SELECT a.Icao, a.Registration, m.Icao, o.Name  FROM Aircraft a, Model m, Operator o WHERE a.ModelID = m.ModelID and a.operatorID = o.operatorID')) as c:
-				for icao24, reg, icaotype, type  in c:
+			with closing(db.execute('SELECT a.Icao, a.Registration, m.Icao, m.Name, o.Name FROM Aircraft a, Model m, Operator o WHERE a.ModelID = m.ModelID and a.operatorID = o.operatorID')) as c:
+				for icao24, reg, icaotype, type, owner in c:
 					bkey = icao24[0:1].upper()
 					dkey = icao24[1:].upper()
 					blocks[bkey][dkey] = {}
 					if reg: blocks[bkey][dkey]['r'] = reg
 					if icaotype: blocks[bkey][dkey]['t'] = icaotype
+					if owner: blocks[bkey][dkey]['o'] = owner
 					if type: blocks[bkey][dkey]['s'] = type
 					ac_count += 1
     print >>sys.stderr, 'Read', ac_count, 'aircraft'

--- a/tools/vrs-basicaircraft-to-json.py
+++ b/tools/vrs-basicaircraft-to-json.py
@@ -30,7 +30,7 @@ def extract(dbfile, todir, blocklimit, debug):
     				if owner: blocks[bkey][dkey]['o'] = owner
     				if type: blocks[bkey][dkey]['s'] = type
     				ac_count += 1
-    else:
+        else:
 		with closing(sqlite3.connect(dbfile)) as db:
 			with closing(db.execute('SELECT a.Icao, a.Registration, m.Icao, o.Name  FROM Aircraft a, Model m, Operator o WHERE a.ModelID = m.ModelID and a.operatorID = o.operatorID')) as c:
 				for icao24, reg, icaotype, type  in c:


### PR DESCRIPTION
Added the manufacturer, model, and owner of aircraft to the GMAP when using BasicAircraftLookup.sqb, and added the ability to parse BaseStation.sqb, which adds a huge number of additional ICAOs.
The default is to use BasicAircraftLookup.sqb, additional work by the user needs to be done to utilize BaseStation.sqb, including manually downloading the database from http://planebase.biz/bstnsqb and altering the cron update script to use the database.

The new DB update script must be run before testing this patch:  

<code>/usr/share/dump1090-mutability/vrs-basicaircraft-to-json.py /var/cache/dump1090-mutability/sqb/BasicAircraftLookup.sqb /var/cache/dump1090-mutability/db/</code>
