### PR TITLE
Add nginx config file for webmap

### DIFF
--- a/debian/dump1090-mutability.install
+++ b/debian/dump1090-mutability.install
@@ -1,5 +1,6 @@
 public_html/* usr/share/dump1090-mutability/html
 debian/lighttpd/* etc/lighttpd/conf-available
+debian/nginx/* etc/nginx/sites-available
 debian/config-template usr/share/dump1090-mutability
 debian/cron-template usr/share/dump1090-mutability
 tools/vrs-basicaircraft-to-json.py usr/share/dump1090-mutability

--- a/debian/nginx/dump1090-mutability
+++ b/debian/nginx/dump1090-mutability
@@ -1,0 +1,19 @@
+# Allows access to the static files that provide the dump1090 map view,
+# and also to the dynamically-generated json parts that contain aircraft
+# data and are periodically written by the dump1090 daemon.
+#
+server{
+        rewrite ^/dump1090/$ /dump1090/gmap.html permanent;
+        rewrite ^/dump1090$ /dump1090/gmap.html permanent;
+
+        location /dump1090/ {
+           alias /usr/share/dump1090-mutability/html/;
+        }
+        location /dump1090/data/ {
+           alias /run/dump1090-mutability/;
+        }
+        location /dump1090/db/ {
+           alias /var/cache/dump1090-mutability/db/;
+        }
+}
+


### PR DESCRIPTION
Add nginx available-site config file. Installation on nginx would be to the sites-available directory, and a symlink to sites-enabled to enable site with default nginx configuration. Checked on Rasbpian Jessie and Ubuntu Wily. 
