### PR TITLE
Remove references to --aggressive from the maint scripts

### DIFF
--- a/debian/dump1090-mutability.config
+++ b/debian/dump1090-mutability.config
@@ -27,7 +27,6 @@ if [ -e $CONFIGFILE ]; then
 
   db_set_yn $NAME/decode-fixcrc "$FIX_CRC"
   db_set_yn $NAME/decode-phase-enhance "$PHASE_ENHANCE"
-  db_set_yn $NAME/decode-aggressive "$AGGRESSIVE"
   db_set $NAME/decode-lat "$LAT"
   db_set $NAME/decode-lon "$LON"
   db_set $NAME/decode-max-range "$MAX_RANGE"
@@ -205,7 +204,6 @@ db_go || true; db_get $NAME/auto-start; if [ "$RET" = "true" ]; then
  fi
 
  db_input low $NAME/decode-fix-crc || true
- db_input low $NAME/decode-aggressive || true
  db_input_verify medium $NAME/decode-max-range is_number || true
  db_input_verify medium $NAME/decode-lat is_number_or_empty || true
 

--- a/debian/dump1090-mutability.postinst
+++ b/debian/dump1090-mutability.postinst
@@ -78,7 +78,6 @@ case "$1" in
         subvar_yn rtlsdr-oversample OVERSAMPLE
         subvar_yn decode-fixcrc FIX_CRC
         subvar_yn decode-phase-enhance PHASE_ENHANCE
-        subvar_yn decode-aggressive AGGRESSIVE
         subvar decode-lat LAT
         subvar decode-lon LON
         subvar decode-max-range MAX_RANGE


### PR DESCRIPTION
Commit 577fe9b removed the debconf template for the option but the
maintainer scripts were still referencing it. This prevented the package
configuration from working.
