### PR TITLE
Fix compilation on OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ CFLAGS+=-std=c11
 COMPAT+=compat/clock_gettime/clock_gettime.o compat/clock_nanosleep/clock_nanosleep.o
 endif
 
+ifeq ($(UNAME), OpenBSD)
+COMPAT+= compat/clock_nanosleep/clock_nanosleep.o
+endif
+
 all: dump1090 view1090
 
 %.o: %.c *.h

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,12 @@ LIBS+=-lrt
 endif
 ifeq ($(UNAME), Darwin)
 # TODO: Putting GCC in C11 mode breaks things.
-CFLAGS+=-std=c11
+CFLAGS+=-std=c11 -DMISSING_GETTIME -DMISSING_NANOSLEEP
 COMPAT+=compat/clock_gettime/clock_gettime.o compat/clock_nanosleep/clock_nanosleep.o
 endif
 
 ifeq ($(UNAME), OpenBSD)
+CFLAGS+= -DMISSING_NANOSLEEP
 COMPAT+= compat/clock_nanosleep/clock_nanosleep.o
 endif
 

--- a/compat/clock_gettime/clock_gettime.h
+++ b/compat/clock_gettime/clock_gettime.h
@@ -16,7 +16,7 @@ typedef enum
     CLOCK_PROCESS_CPUTIME_ID,
     CLOCK_THREAD_CPUTIME_ID
 } clockid_t;
-#endif // CLOCKID_T
+#endif // ifndef CLOCKID_T
 
 struct timespec;
 

--- a/compat/clock_gettime/clock_gettime.h
+++ b/compat/clock_gettime/clock_gettime.h
@@ -1,7 +1,11 @@
 #ifndef CLOCK_GETTIME_H
 #define CLOCK_GETTIME_H
 
-#include <mach/mach_time.h>
+#include <mach/mach_time.h> // Apple-only, but this isn't inclued on other BSDs
+
+#ifdef _CLOCKID_T_DEFINED_
+#define CLOCKID_T
+#endif
 
 #ifndef CLOCKID_T
 #define CLOCKID_T

--- a/compat/clock_nanosleep/clock_nanosleep.c
+++ b/compat/clock_nanosleep/clock_nanosleep.c
@@ -19,10 +19,13 @@
  *  http://www.gnu.org/copyleft/gpl.html                               *
  ***********************************************************************/
 
-#include "clock_nanosleep.h"
 #include <errno.h>                           // for errno, EINVAL
 #include <time.h>                            // for nanosleep, NULL
+
+#include "clock_nanosleep.h"
+#ifdef MISSING_GETTIME
 #include "../clock_gettime/clock_gettime.h"  // for clock_gettime
+#endif
 
 int clock_nanosleep(clockid_t id, int flags, const struct timespec *ts,
                     struct timespec *ots) {

--- a/compat/clock_nanosleep/clock_nanosleep.h
+++ b/compat/clock_nanosleep/clock_nanosleep.h
@@ -1,6 +1,10 @@
 #ifndef CLOCK_NANOSLEEP_H
 #define CLOCK_NANOSLEEP_H
 
+#ifdef _CLOCKID_T_DEFINED_
+#define CLOCKID_T
+#endif
+
 #ifndef CLOCKID_T
 #define CLOCKID_T
 typedef enum

--- a/compat/clock_nanosleep/clock_nanosleep.h
+++ b/compat/clock_nanosleep/clock_nanosleep.h
@@ -1,8 +1,8 @@
 #ifndef CLOCK_NANOSLEEP_H
 #define CLOCK_NANOSLEEP_H
 
-#ifndef _CLOCK_T_DEFINED_
-#define _CLOCK_T_DEFINED_
+#ifndef CLOCKID_T
+#define CLOCKID_T
 typedef enum
 {
     CLOCK_REALTIME,
@@ -10,7 +10,8 @@ typedef enum
     CLOCK_PROCESS_CPUTIME_ID,
     CLOCK_THREAD_CPUTIME_ID
 } clockid_t;
-#endif // _CLOCK_T_DEFINED_
+#endif // ifndef CLOCKID_T
+
 
 #ifndef TIMER_ABSTIME
 #define TIMER_ABSTIME 1

--- a/compat/clock_nanosleep/clock_nanosleep.h
+++ b/compat/clock_nanosleep/clock_nanosleep.h
@@ -1,8 +1,8 @@
 #ifndef CLOCK_NANOSLEEP_H
 #define CLOCK_NANOSLEEP_H
 
-#ifndef CLOCKID_T
-#define CLOCKID_T
+#ifndef _CLOCK_T_DEFINED_
+#define _CLOCK_T_DEFINED_
 typedef enum
 {
     CLOCK_REALTIME,
@@ -10,7 +10,7 @@ typedef enum
     CLOCK_PROCESS_CPUTIME_ID,
     CLOCK_THREAD_CPUTIME_ID
 } clockid_t;
-#endif // CLOCKID_T
+#endif // _CLOCK_T_DEFINED_
 
 #ifndef TIMER_ABSTIME
 #define TIMER_ABSTIME 1

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -9,8 +9,8 @@
 
 /* implementations of clock_gettime, clock_nanosleep */
 
-#include "clock_gettime/clock_gettime.h"
-#include "clock_nanosleep/clock_nanosleep.h"
+#define MISSING_NANOSLEEP
+#define MISSING_GETTIME
 
 /*
  * Mach endian conversion
@@ -27,6 +27,18 @@
 
 # include <endian.h>
 
+#endif
+
+#if defined(__OpenBSD__)
+#define MISSING_NANOSLEEP
+#endif
+
+#ifdef MISSING_NANOSLEEP
+#include "clock_nanosleep/clock_nanosleep.h"
+#endif
+
+#ifdef MISSING_GETTIME
+#include "clock_nanosleep/clock_gettime.h"
 #endif
 
 #endif //COMPAT_UTIL_H

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -7,11 +7,6 @@
 
 #if defined(__APPLE__)
 
-/* implementations of clock_gettime, clock_nanosleep */
-
-#define MISSING_NANOSLEEP
-#define MISSING_GETTIME
-
 /*
  * Mach endian conversion
  */
@@ -29,16 +24,12 @@
 
 #endif
 
-#if defined(__OpenBSD__)
-#define MISSING_NANOSLEEP
-#endif
-
 #ifdef MISSING_NANOSLEEP
 #include "clock_nanosleep/clock_nanosleep.h"
 #endif
 
 #ifdef MISSING_GETTIME
-#include "clock_nanosleep/clock_gettime.h"
+#include "clock_gettime/clock_gettime.h"
 #endif
 
 #endif //COMPAT_UTIL_H

--- a/net_io.c
+++ b/net_io.c
@@ -1316,7 +1316,7 @@ static int handleHTTPRequest(struct client *c, char *p) {
     const char *statusmsg = "Internal Server Error";
     char *url, *content = NULL;
     char *ext;
-    char *content_type;
+    char *content_type = NULL;
     int i;
 
     if (Modes.debug & MODES_DEBUG_NET)


### PR DESCRIPTION
OpenBSD 3.9 has clock_gettime() but no clock_clocknanosleep().

Tested on OS X and OpenBSD.
