### PR TITLE
Problems compiling using stock makefile with Homebrew on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 CPPFLAGS+=-DMODES_DUMP1090_VERSION=\"$(DUMP1090_VERSION)\"
 CFLAGS+=-O2 -g -Wall -Werror -W
 LIBS=-lpthread -lm
-LIBS_RTL=`pkg-config --libs librtlsdr`
+LIBS_RTL=`pkg-config --libs librtlsdr libusb-1.0`
 CC=gcc
 
 UNAME := $(shell uname)


### PR DESCRIPTION
I added libusb-1.0 to the list of libs handled by pkg-config, but I'm not sure why this wasn't this way to being with.

```
$ pkg-config --libs librtlsdr libusb-1.0
-L/usr/local/Cellar/librtlsdr/0.5.3/lib -L/usr/local/Cellar/libusb/1.0.20/lib -lrtlsdr -lusb-1.0
```
