### PR TITLE
Correct typo? in dump1090-mutability.init line 64

### DIFF
--- a/debian/dump1090-mutability.init
+++ b/debian/dump1090-mutability.init
@@ -61,7 +61,7 @@ if [ -n "$PPM" ]; then ARGS="$ARGS --ppm $PPM"; fi
 if [ "x$FIX_CRC" = "xyes" ]; then ARGS="$ARGS --fix"; fi
 if [ -n "$LAT" ]; then ARGS="$ARGS --lat $LAT"; fi
 if [ -n "$LON" ]; then ARGS="$ARGS --lon $LON"; fi
-ARGS="$ARGS --max-range $MAX_RANGE"; fi
+if [ -n "$MAX_RANGE" ]; then ARGS="$ARGS --max-range $MAX_RANGE"; fi
 
 # net:
 


### PR DESCRIPTION
A bit of line 64 seems to have been removed / lost, which is causing new installs to fail to start (at least on my C.H.I.P.).  I tried adding back the same "if []" bits as the previous lines, and it worked great on my system.
