### PR TITLE
Use _DEFAULT_SOURCE, not deprecated _BSD_SOURCE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ UNAME := $(shell uname)
 
 ifeq ($(UNAME), Linux)
 LIBS+=-lrt
-CFLAGS+=-std=c11 -D_BSD_SOURCE=1 -D_POSIX_C_SOURCE=200809L
+CFLAGS+=-std=c11 -D_DEFAULT_SOURCE=1 -D_POSIX_C_SOURCE=200809L
 endif
 ifeq ($(UNAME), Darwin)
 # TODO: Putting GCC in C11 mode breaks things.


### PR DESCRIPTION
This fixes the compile error introduced in commit f152bf6. Reported in #142.

/usr/include/features.h:148:3: error: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Werror=cpp]
