### PR TITLE
Adjust precision of feet -> meters conversion

### DIFF
--- a/interactive.c
+++ b/interactive.c
@@ -56,7 +56,7 @@
 static int convert_altitude(int ft)
 {
     if (Modes.metric)
-        return (ft / 3.2828);
+        return (ft * 0.3048);
     else
         return ft;
 }

--- a/public_html/formatter.js
+++ b/public_html/formatter.js
@@ -41,7 +41,7 @@ function format_altitude_brief(alt, vr) {
 	}
 	
 	if (Metric) {
-		alt_text = Math.round(alt / 3.2828) + NBSP; // Altitude to meters
+		alt_text = Math.round(alt * 0.3048) + NBSP; // Altitude to meters
 	} else {
 		alt_text = Math.round(alt) + NBSP;
 	}
@@ -59,7 +59,7 @@ function format_altitude_brief(alt, vr) {
 // alt in ft
 function _alt_to_unit(alt, m) {
 	if (m)
-		return Math.round(alt / 3.2828) + NBSP + "m";
+		return Math.round(alt * 0.3048) + NBSP + "m";
 	else
 		return Math.round(alt) + NBSP + "ft";
 }


### PR DESCRIPTION
From https://en.wikipedia.org/wiki/Foot_(unit), the foot is recognized
as being exactly 0.3048 meters. It isn't clear where the former
conversion factor of 3.2828 came from, as it really should be
1 / 0.3048 = 3.28084.

In any case, we're better off just using the official value, as we can
multiply rather than divide.

For an altitude of 37,000 feet, the old code gives 11,270.9 meters, and the new code gives 11,277.6 meters. Not exactly a huge difference, but seems worth getting it right.
