### PR TITLE
Added Australian hexid->registration conversion

### DIFF
--- a/public_html/registrations.js
+++ b/public_html/registrations.js
@@ -53,6 +53,7 @@ registration_from_hexid = (function () {
                 { start: 0x760421, s1: 1024,  s2: 32, prefix: "AP-" },
                 { start: 0x768421, s1: 1024,  s2: 32, prefix: "9V-" },
                 { start: 0x778421, s1: 1024,  s2: 32, prefix: "YK-" },
+                { start: 0x778421, s1: 1296,  s2: 36, prefix: "VH-" },
                 { start: 0xC00001, s1: 26*26, s2: 26, prefix: "C-F" },
                 { start: 0xC044A9, s1: 26*26, s2: 26, prefix: "C-G" },
                 { start: 0xE01041, s1: 4096,  s2: 64, prefix: "LV-" }
@@ -117,10 +118,6 @@ registration_from_hexid = (function () {
                         return reg;
 
                 reg = hl_reg(hexid);
-                if (reg)
-                        return reg;
-
-                reg = vh_reg(hexid);
                 if (reg)
                         return reg;
 
@@ -308,25 +305,6 @@ registration_from_hexid = (function () {
                 offset -= 340;
                 var letter3 = Math.floor(offset / 24);
                 return reg + limited_alphabet.charAt(letter3) + limited_alphabet.charAt(offset % 24);
-        }
-
-        // Australia
-        function vh_reg(hexid) {
-            var offset = hexid - 0x7C0000;
-            if (offset < 0 || offset > 33325)
-                return null;
-
-            var reg = "VH-";
-
-            reg += full_alphabet.charAt(Math.floor(offset / 1296));
-            offset = offset % 1296;
-            
-            reg += full_alphabet.charAt(Math.floor(offset / 36));
-            offset = offset % 36;
-            
-            reg += full_alphabet.charAt(offset);
-
-            return reg;
         }
 
         return lookup;

--- a/public_html/registrations.js
+++ b/public_html/registrations.js
@@ -53,7 +53,7 @@ registration_from_hexid = (function () {
                 { start: 0x760421, s1: 1024,  s2: 32, prefix: "AP-" },
                 { start: 0x768421, s1: 1024,  s2: 32, prefix: "9V-" },
                 { start: 0x778421, s1: 1024,  s2: 32, prefix: "YK-" },
-                { start: 0x778421, s1: 1296,  s2: 36, prefix: "VH-" },
+                { start: 0x7C0000, s1: 1296,  s2: 36, prefix: "VH-" },
                 { start: 0xC00001, s1: 26*26, s2: 26, prefix: "C-F" },
                 { start: 0xC044A9, s1: 26*26, s2: 26, prefix: "C-G" },
                 { start: 0xE01041, s1: 4096,  s2: 64, prefix: "LV-" }

--- a/public_html/registrations.js
+++ b/public_html/registrations.js
@@ -120,6 +120,10 @@ registration_from_hexid = (function () {
                 if (reg)
                         return reg;
 
+                reg = vh_reg(hexid);
+                if (reg)
+                        return reg;
+
                 reg = numeric_reg(hexid);
                 if (reg)
                         return reg;
@@ -304,6 +308,25 @@ registration_from_hexid = (function () {
                 offset -= 340;
                 var letter3 = Math.floor(offset / 24);
                 return reg + limited_alphabet.charAt(letter3) + limited_alphabet.charAt(offset % 24);
+        }
+
+        // Australia
+        function vh_reg(hexid) {
+            var offset = hexid - 0x7C0000;
+            if (offset < 0 || offset > 33325)
+                return null;
+
+            var reg = "VH-";
+
+            reg += full_alphabet.charAt(Math.floor(offset / 1296));
+            offset = offset % 1296;
+            
+            reg += full_alphabet.charAt(Math.floor(offset / 36));
+            offset = offset % 36;
+            
+            reg += full_alphabet.charAt(offset);
+
+            return reg;
         }
 
         return lookup;


### PR DESCRIPTION
This change allows for the conversion of Australian ICAO24 addresses into their VH registrations (VH-AAA thru VH-ZZZ).