### PR TITLE
Makefile updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 PROGNAME=dump1090
 
 ifndef DUMP1090_VERSION
-DUMP1090_VERSION=$(shell git describe --tags --match=v*)
+DUMP1090_VERSION=$(shell git describe --always --tags --match=v*)
 endif
 
 ifdef PREFIX

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ endif
 CPPFLAGS+=-DMODES_DUMP1090_VERSION=\"$(DUMP1090_VERSION)\"
 CFLAGS+=-O2 -g -Wall -Werror -W
 LIBS=-lpthread -lm
+CFLAGS_RTL=`pkg-config --cflags librtlsdr libusb-1.0`
 LIBS_RTL=`pkg-config --libs librtlsdr libusb-1.0`
 CC=gcc
 
@@ -46,7 +47,7 @@ endif
 all: dump1090 view1090
 
 %.o: %.c *.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(EXTRACFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_RTL) $(EXTRACFLAGS) -c $< -o $@
 
 dump1090.o: CFLAGS += `pkg-config --cflags librtlsdr`
 


### PR DESCRIPTION
Depending on how a user gets the repo, it may not include tags, which can generate "fatal: No names found, cannot describe anything." messages as each object is built. The --always flag will fall back to an abbreviated hash if it can't find any suitable tags, and no "fatal" messages are generated.