### PR TITLE
fallback if missing repo tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 PROGNAME=dump1090
 
 ifndef DUMP1090_VERSION
-DUMP1090_VERSION=$(shell git describe --tags --match=v*)
+DUMP1090_VERSION=$(shell git describe --always --tags --match=v*)
 endif
 
 ifdef PREFIX


### PR DESCRIPTION
Depending on how a user gets the repo, it may not include tags, which can generate "fatal: No names found, cannot describe anything." messages as each object is built. The --always flag will fall back to an abbreviated hash if it can't find any suitable tags, and no "fatal" messages are generated.