### PR TITLE
Remove Chartbundle WAC charts.

### DIFF
--- a/public_html/layers.js
+++ b/public_html/layers.js
@@ -45,7 +45,7 @@ function createBaseLayers() {
                 var chartbundleTypes = {
                         sec: "Sectional Charts",
                         tac: "Terminal Area Charts",
-                        wac: "World Aeronautical Charts",
+                        hel: "Helicopter Charts",
                         enrl: "IFR Enroute Low Charts",
                         enra: "IFR Area Charts",
                         enrh: "IFR Enroute High Charts"


### PR DESCRIPTION
Chartbundle no longer supports WAC charts as the FAA no longer publishes them.

Removes WAC.
Adds Helicopter Charts, which have fairly limited coverage.