### PR TITLE
Add mavlink output support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mavlink"]
+	path = mavlink
+	url = https://github.com/mavlink/c_library_v2.git

--- a/dump1090.c
+++ b/dump1090.c
@@ -153,6 +153,10 @@ void modesInitConfig(void) {
 #ifdef ENABLE_WEBSERVER
     Modes.net_http_ports          = strdup("8080");
 #endif
+#ifdef ENABLE_MAVLINK
+    Modes.mavlink_target_ip       = strdup("127.0.0.1");
+    Modes.mavlink_target_port     = 14550;
+#endif
     Modes.interactive_rows        = getTermRows();
     Modes.interactive_display_ttl = MODES_INTERACTIVE_DISPLAY_TTL;
     Modes.html_dir                = HTMLPATH;
@@ -693,6 +697,10 @@ void showHelp(void) {
 #ifdef ENABLE_WEBSERVER
 "--net-http-port <ports>  HTTP server ports (default: 8080)\n"
 #endif
+#ifdef ENABLE_MAVLINK
+"--mavlink-target-ip <addr> Mavlink target ip (default: 127.0.0.1)\n"
+"--mavlink-target-port <port> Mavlink target udp port (default: 14550)\n"
+#endif
 "--net-ri-port <ports>    TCP raw input listen ports  (default: 30001)\n"
 "--net-ro-port <ports>    TCP raw output listen ports (default: 30002)\n"
 "--net-sbs-port <ports>   TCP BaseStation output listen ports (default: 30003)\n"
@@ -1015,6 +1023,18 @@ int main(int argc, char **argv) {
             if (strcmp(argv[++j], "0")) {
                 fprintf(stderr, "warning: --net-http-port not supported in this build, option ignored.\n");
             }
+#endif
+        } else if (!strcmp(argv[j],"--mavlink-target-ip") && more) {
+#ifdef ENABLE_MAVLINK
+            Modes.mavlink_target_ip = strdup(argv[++j]);
+#else
+            fprintf(stderr, "warning: --mavlink-target-ip is not supported in this build, option ignored.\n");
+#endif
+        } else if (!strcmp(argv[j],"--mavlink-target-port") && more) {
+#ifdef ENABLE_MAVLINK
+            Modes.mavlink_target_port = atoi(argv[++j]);
+#else
+            fprintf(stderr, "warning: --mavlink-target-port is not supported in this build, option ignored.\n");
 #endif
         } else if (!strcmp(argv[j],"--net-sbs-port") && more) {
             free(Modes.net_output_sbs_ports);

--- a/dump1090.h
+++ b/dump1090.h
@@ -78,10 +78,16 @@
     #include <sys/ioctl.h>
     #include <time.h>
     #include <limits.h>
+    #include <sys/types.h>
+    #include <sys/socket.h>
+    #include <netinet/in.h>
+    #include <netinet/udp.h>
+    #include <arpa/inet.h>
 #else
     #include "winstubs.h" //Put everything Windows specific in here
 #endif
 
+#include "mavlink/common/mavlink.h"
 #include "compat/compat.h"
 
 // Avoid a dependency on rtl-sdr except where it's really needed.
@@ -333,6 +339,10 @@ struct {                             // Internal state
 #ifdef ENABLE_WEBSERVER
     char *net_http_ports;            // List of HTTP ports
 #endif
+#ifdef ENABLE_MAVLINK
+    char *mavlink_target_ip;
+    int   mavlink_target_port;
+#endif
     char *net_bind_address;          // Bind address
     int   net_sndbuf_size;           // TCP output buffer size (64Kb * 2^n)
     int   net_verbatim;              // if true, send the original message, not the CRC-corrected one
@@ -568,7 +578,8 @@ void useModesMessage    (struct modesMessage *mm);
 //
 // Functions exported from interactive.c
 //
-void  interactiveShowData(void);
+void interactiveShowData(void);
+void mavlink_send_aircraft(struct aircraft *a);
 
 #ifdef __cplusplus
 }

--- a/track.h
+++ b/track.h
@@ -73,6 +73,7 @@ struct aircraft {
 
     uint64_t      seen;           // Time (millis) at which the last packet was received
     long          messages;       // Number of Mode S messages received
+    long          mavlink_messages_last;  // Number of Mode S messages when sending last mavlink packet
 
     double        signalLevel[8]; // Last 8 Signal Amplitudes
     int           signalNext;     // next index of signalLevel to use


### PR DESCRIPTION
Add support for mavlink output (using UDP stream). Compatible with PX4 flight stack and QGroundControl.